### PR TITLE
Allow result submission to origin daemon with self-select

### DIFF
--- a/src/base/io/log/Tags.cpp
+++ b/src/base/io/log/Tags.cpp
@@ -36,6 +36,12 @@ const char *xmrig::Tags::network()
     return tag;
 }
 
+const char* xmrig::Tags::origin()
+{
+    static const char* tag = YELLOW_BG_BOLD(WHITE_BOLD_S " origin  ");
+
+    return tag;
+}
 
 const char *xmrig::Tags::signal()
 {

--- a/src/base/io/log/Tags.h
+++ b/src/base/io/log/Tags.h
@@ -32,6 +32,7 @@ class Tags
 public:
     static const char *config();
     static const char *network();
+    static const char *origin();
     static const char *signal();
 
 #   ifdef XMRIG_MINER_PROJECT

--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -260,6 +260,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::DryRunKey:      /* --dry-run */
     case IConfig::HttpEnabledKey: /* --http-enabled */
     case IConfig::DaemonKey:      /* --daemon */
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
     case IConfig::VerboseKey:     /* --verbose */
     case IConfig::PauseOnBatteryKey: /* --pause-on-battery */
         return transformBoolean(doc, key, true);
@@ -289,6 +290,9 @@ void xmrig::BaseTransform::transformBoolean(rapidjson::Document &doc, int key, b
 
     case IConfig::TlsKey: /* --tls */
         return add(doc, Pools::kPools, Pool::kTls, enable);
+
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
+        return add(doc, Pools::kPools, Pool::kSubmitToOrigin, enable);
 
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonKey: /* --daemon */

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -73,6 +73,7 @@ public:
         DaemonKey            = 1018,
         DaemonPollKey        = 1019,
         SelfSelectKey        = 1028,
+        SubmitToOriginKey    = 1049,
         DataDirKey           = 1035,
         TitleKey             = 1037,
         NoTitleKey           = 1038,

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -72,6 +72,7 @@ public:
     static const char *kPass;
     static const char *kRigId;
     static const char *kSelfSelect;
+    static const char* kSubmitToOrigin;
     static const char *kSOCKS5;
     static const char *kTls;
     static const char *kUrl;
@@ -156,6 +157,7 @@ private:
     uint64_t m_pollInterval         = kDefaultPollInterval;
     Url m_daemon;
     Url m_url;
+    bool m_submit_to_origin         = false;
 
 #   ifdef XMRIG_FEATURE_BENCHMARK
     std::shared_ptr<BenchConfig> m_benchmark;

--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -31,9 +31,12 @@
 #include "base/io/json/Json.h"
 #include "base/io/json/JsonRequest.h"
 #include "base/io/log/Log.h"
+#include "base/io/log/Tags.h"
 #include "base/net/http/Fetch.h"
 #include "base/net/http/HttpData.h"
 #include "base/net/stratum/Client.h"
+#include "net/JobResult.h"
+#include "base/tools/Cvt.h"
 
 
 namespace xmrig {
@@ -54,8 +57,8 @@ static const char * const required_fields[] = { kBlocktemplateBlob, kBlockhashin
 } /* namespace xmrig */
 
 
-xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener) :
-    m_listener(listener)
+xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin) :
+    m_listener(listener), m_submit_to_origin(submit_to_origin)
 {
     m_httpListener  = std::make_shared<HttpListener>(this);
     m_client        = new Client(id, agent, this);
@@ -93,7 +96,6 @@ void xmrig::SelfSelectClient::onJobReceived(IClient *, const Job &job, const rap
 void xmrig::SelfSelectClient::onLogin(IClient *, rapidjson::Document &doc, rapidjson::Value &params)
 {
     params.AddMember("mode", "self-select", doc.GetAllocator());
-
     m_listener->onLogin(this, doc, params);
 }
 
@@ -201,6 +203,9 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     Document doc(kObjectType);
     auto &allocator = doc.GetAllocator();
 
+    m_blocktemplate = Json::getString(result,kBlocktemplateBlob);
+    m_targetdiff = Json::getUint64(result, kDifficulty);
+
     Value params(kObjectType);
     params.AddMember(StringRef(kId),            m_job.clientId().toJSON(), allocator);
     params.AddMember(StringRef(kJobId),         m_job.id().toJSON(), allocator);
@@ -235,6 +240,47 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     });
 }
 
+int64_t xmrig::SelfSelectClient::submit(const JobResult& result)
+{
+    if (m_submit_to_origin) {
+        submitOriginDaemon(result);
+    }
+    return m_client->submit(result);
+}
+
+void xmrig::SelfSelectClient::submitOriginDaemon(const JobResult& result)
+{
+    if (result.diff == 0 || m_targetdiff == 0) {
+        return;
+    }
+    
+    if (result.actualDiff() < m_targetdiff) {
+        m_origin_not_submitted++;
+        LOG_INFO("%s " RED_BOLD("not submitted to origin daemon, difficulty too low") " (%" PRId64 "/%" PRId64 ") "
+            BLACK_BOLD(" diff ") BLACK_BOLD("%" PRIu64) BLACK_BOLD(" vs. ") BLACK_BOLD("%" PRIu64),
+            Tags::origin(), m_origin_submitted, m_origin_not_submitted, m_targetdiff, result.actualDiff());
+        return;
+    }
+    char *data = m_blocktemplate.data();
+    Cvt::toHex(data + 78, 8, reinterpret_cast<const uint8_t*>(&result.nonce), 4);
+
+    using namespace rapidjson;
+    Document doc(kObjectType);
+
+    Value params(kArrayType);
+    params.PushBack(m_blocktemplate.toJSON(), doc.GetAllocator());
+
+    JsonRequest::create(doc, m_sequence, "submitblock", params);
+    m_results[m_sequence] = SubmitResult(m_sequence, result.diff, result.actualDiff(), 0, result.backend);
+
+    FetchRequest req(HTTP_POST, pool().daemon().host(), pool().daemon().port(), "/json_rpc", doc, pool().daemon().isTLS(), isQuiet());
+    fetch(tag(), std::move(req), m_httpListener);
+
+    m_origin_submitted++;
+    LOG_INFO("%s " GREEN_BOLD("submitted to origin daemon") " (%" PRId64 "/%" PRId64 ") " 
+        " diff " WHITE("%" PRIu64) " vs. " WHITE("%" PRIu64),
+        Tags::origin(), m_origin_submitted, m_origin_not_submitted, m_targetdiff, result.actualDiff(), result.diff);
+}
 
 void xmrig::SelfSelectClient::onHttpData(const HttpData &data)
 {

--- a/src/base/net/stratum/SelfSelectClient.h
+++ b/src/base/net/stratum/SelfSelectClient.h
@@ -35,6 +35,7 @@
 
 
 #include <memory>
+#include <map>
 
 
 namespace xmrig {
@@ -45,7 +46,7 @@ class SelfSelectClient : public IClient, public IClientListener, public IHttpLis
 public:
     XMRIG_DISABLE_COPY_MOVE_DEFAULT(SelfSelectClient)
 
-    SelfSelectClient(int id, const char *agent, IClientListener *listener);
+    SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin);
     ~SelfSelectClient() override;
 
 protected:
@@ -65,7 +66,7 @@ protected:
     inline int64_t send(const rapidjson::Value &obj, Callback callback) override    { return m_client->send(obj, callback); }
     inline int64_t send(const rapidjson::Value &obj) override                       { return m_client->send(obj); }
     inline int64_t sequence() const override                                        { return m_client->sequence(); }
-    inline int64_t submit(const JobResult &result) override                         { return m_client->submit(result); }
+    inline int64_t submit(const JobResult &result) override;
     inline void connect() override                                                  { m_client->connect(); }
     inline void connect(const Pool &pool) override                                  { m_client->connect(pool); }
     inline void deleteLater() override                                              { m_client->deleteLater(); }
@@ -105,7 +106,7 @@ private:
     void retry();
     void setState(State state);
     void submitBlockTemplate(rapidjson::Value &result);
-
+    inline void submitOriginDaemon(const JobResult &result);
     bool m_active           = false;
     bool m_quiet            = false;
     IClient *m_client;
@@ -115,9 +116,15 @@ private:
     int64_t m_sequence      = 1;
     Job m_job;
     State m_state           = IdleState;
+    String m_blocktemplate;
+    bool m_submit_to_origin = false;
+    std::map<int64_t, SubmitResult> m_results;
     std::shared_ptr<IHttpListener> m_httpListener;
     uint64_t m_retryPause   = 5000;
     uint64_t m_timestamp    = 0;
+    uint64_t m_targetdiff   = 0;
+    uint64_t m_origin_submitted = 0;
+    uint64_t m_origin_not_submitted = 0;
 };
 
 

--- a/src/config.json
+++ b/src/config.json
@@ -75,7 +75,8 @@
             "tls-fingerprint": null,
             "daemon": false,
             "socks5": null,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -107,7 +107,8 @@ R"===(
             "tls": false,
             "tls-fingerprint": null,
             "daemon": false,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -57,6 +57,7 @@ static const option options[] = {
     { "daemon",                0, nullptr, IConfig::DaemonKey             },
     { "daemon-poll-interval",  1, nullptr, IConfig::DaemonPollKey         },
     { "self-select",           1, nullptr, IConfig::SelfSelectKey         },
+    { "submit-to-origin",      0, nullptr, IConfig::SubmitToOriginKey     },
 #   endif
     { "av",                    1, nullptr, IConfig::AVKey                 },
     { "background",            0, nullptr, IConfig::BackgroundKey         },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -64,6 +64,7 @@ static inline const std::string &usage()
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";
     u += "      --daemon-poll-interval=N  daemon poll interval in milliseconds (default: 1000)\n";
     u += "      --self-select=URL         self-select block templates from URL\n";
+    u += "      --submit-to-origin        also submit solution back to self-select URL\n";
 #   endif
 
     u += "  -r, --retries=N               number of times to retry before switch to backup server (default: 5)\n";


### PR DESCRIPTION
Allow result submission to origin daemon with self-select.

With `self-select` mode enabled, the `submit-to-origin` config option will let the `SelfSelectClient` submit the solution to both the origin daemon where it got the template from as well as to the connected pool. Submission to the origin daemon will only be done if achieved difficulty is equal to or higher than the target difficulty received with the block template.

This will enable pool mining for Monero in conjunction with solo merged mining with an altcoin.

Thank you and special credit to @StriderDM (https://github.com/StriderDM)!

Example console output:
``` rust
 * ABOUT        XMRig/6.7.3-dev MSVC/2019
 * LIBS         libuv/1.40.0 OpenSSL/1.1.1h
 * HUGE PAGES   permission granted
 * 1GB PAGES    unavailable
 * CPU          Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (1) 64-bit AES VM
                threads:8
 * MEMORY       12.1/31.9 GB (38%)
 * DONATE       1%
 * ASSEMBLY     auto:intel
 * POOL #1      cryptonote.social:5555 coin monero self-select 127.0.0.1:7878 submit-to-origin
 * COMMANDS     hashrate, pause, resume, results, connection
 * OPENCL       disabled
 * CUDA         disabled
[2021-01-18 11:40:32.206]  net      use pool cryptonote.social:5555  75.144.254.101
[2021-01-18 11:40:33.235]  net      new job from cryptonote.social:5555 diff 220006 algo rx/0 height 2277083
[2021-01-18 11:40:33.235]  cpu      use argon2 implementation AVX2
[2021-01-18 11:40:33.413]  msr      register values for "intel" preset has been set successfully (177 ms)
[2021-01-18 11:40:33.413]  randomx  init dataset algo rx/0 (8 threads) seed c16b9816e30cf2bc...
[2021-01-18 11:40:33.863]  randomx  allocated 2336 MB (2080+256) huge pages 100% 1168/1168 +JIT (450 ms)
[2021-01-18 11:40:38.199]  randomx  dataset ready (4336 ms)
[2021-01-18 11:40:38.200]  cpu      use profile  rx  (4 threads) scratchpad 2048 KB
[2021-01-18 11:40:38.262]  cpu      READY threads 4/4 (4) huge pages 100% 4/4 memory 8192 KB (62 ms)
[2021-01-18 11:40:48.392]  net      new job from cryptonote.social:5555 diff 220006 algo rx/0 height 2277084
[2021-01-18 11:41:22.378]  origin   submitted to origin daemon (1/0)  diff 284557 vs. 371742
[2021-01-18 11:41:22.812]  cpu      accepted (1/0) diff 220006 (433 ms)
[2021-01-18 11:41:39.201]  miner    speed 10s/60s/15m 1562.2 1630.4 n/a H/s max 1710.0 H/s
[2021-01-18 11:42:05.837]  origin   not submitted to origin daemon, difficulty too low (1/1)  diff 284557 vs. 230465
[2021-01-18 11:42:06.320]  cpu      accepted (2/0) diff 220006 (482 ms)
```