### PR TITLE
Update block template

### DIFF
--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -280,6 +280,9 @@ void xmrig::SelfSelectClient::submitOriginDaemon(const JobResult& result)
     LOG_INFO("%s " GREEN_BOLD("submitted to origin daemon") " (%" PRId64 "/%" PRId64 ") " 
         " diff " WHITE("%" PRIu64) " vs. " WHITE("%" PRIu64),
         Tags::origin(), m_origin_submitted, m_origin_not_submitted, m_targetdiff, result.actualDiff(), result.diff);
+
+    // Ensure that the latest block template is available after block submission
+    getBlockTemplate();
 }
 
 void xmrig::SelfSelectClient::onHttpData(const HttpData &data)


### PR DESCRIPTION
This PR ensures that the Tari block template is updated after a block submission and submitted to the pool.
  `getBlockTemplate()` results in
  `parseResponse(..)` when result is returned
  with `submitBlockTemplate(..)` to the pool

This is to ensure no downtime is experienced by the miner w.r.t. solving the wrong Tari block template after successful submission and also that the pool is aware the block template changed.

See XMRig console output below. 
- Notice the timings between:
  - `origin   submitted to origin daemon` 
  - `cpu      accepted` 
  - `net      new job from cryptonote.social:5555` 
- The `[127.0.0.1:7878] error: "Block not accepted", code: -7` messages are from the proxy because the block should not be submitted to `monerod` as well, that is handled by the pool, and a topic for a next PR to fix in the proxy.

``` rust
 * ABOUT        XMRig/6.7.2 MSVC/2019
 * LIBS         libuv/1.40.0 OpenSSL/1.1.1h
 * HUGE PAGES   permission granted
 * 1GB PAGES    unavailable
 * CPU          Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (1) 64-bit AES VM
                threads:8
 * MEMORY       11.0/31.9 GB (35%)
 * DONATE       1%
 * ASSEMBLY     auto:intel
 * POOL #1      cryptonote.social:5555 coin monero self-select 127.0.0.1:7878 submit-to-origin
 * COMMANDS     hashrate, pause, resume, results, connection
 * OPENCL       disabled
 * CUDA         disabled
[2021-01-20 17:34:55.104]  net      use pool cryptonote.social:5555  75.144.254.101
[2021-01-20 17:34:56.164]  net      new job from cryptonote.social:5555 diff 90001 algo rx/0 height 2278697
[2021-01-20 17:34:56.165]  cpu      use argon2 implementation AVX2
[2021-01-20 17:34:56.167]  msr      to write MSR registers Administrator privileges required.
[2021-01-20 17:34:56.168]  msr      FAILED TO APPLY MSR MOD, HASHRATE WILL BE LOW
[2021-01-20 17:34:56.169]  randomx  init dataset algo rx/0 (8 threads) seed 99a9701212ff499e...
[2021-01-20 17:34:56.171]  randomx  allocated 2336 MB (2080+256) huge pages 100% 1168/1168 +JIT (0 ms)
[2021-01-20 17:34:58.779]  net      new job from cryptonote.social:5555 diff 90001 algo rx/0 height 2278698
[2021-01-20 17:35:00.659]  randomx  dataset ready (4487 ms)
[2021-01-20 17:35:00.660]  cpu      use profile  rx  (4 threads) scratchpad 2048 KB
[2021-01-20 17:35:00.678]  cpu      READY threads 4/4 (4) huge pages 100% 4/4 memory 8192 KB (4 ms)
[2021-01-20 17:36:01.475]  miner    speed 10s/60s/15m 1410.1 1414.9 n/a H/s max 1603.4 H/s
[2021-01-20 17:37:02.277]  miner    speed 10s/60s/15m 1552.8 1366.7 n/a H/s max 1603.4 H/s
[2021-01-20 17:37:43.376]  origin   not submitted to origin daemon, difficulty too low (0/1)  diff 262685 vs. 239645
[2021-01-20 17:37:43.755]  cpu      accepted (1/0) diff 90001 (378 ms)
[2021-01-20 17:37:59.842]  origin   submitted to origin daemon (1/1)  diff 262685 vs. 468034
[2021-01-20 17:38:00.206]  cpu      accepted (2/0) diff 90001 (365 ms)
[2021-01-20 17:38:00.436] [127.0.0.1:7878] error: "Block not accepted", code: -7
[2021-01-20 17:38:00.891]  net      new job from cryptonote.social:5555 diff 90001 algo rx/0 height 2278698
[2021-01-20 17:38:03.084]  miner    speed 10s/60s/15m 1471.7 1498.6 n/a H/s max 1659.9 H/s
[2021-01-20 17:38:55.716]  origin   submitted to origin daemon (2/1)  diff 262685 vs. 370681
[2021-01-20 17:38:56.072]  cpu      accepted (3/0) diff 90001 (351 ms)
[2021-01-20 17:38:56.143] [127.0.0.1:7878] error: "Block not accepted", code: -7
[2021-01-20 17:38:56.772]  net      new job from cryptonote.social:5555 diff 90001 algo rx/0 height 2278698
[2021-01-20 17:39:03.779]  miner    speed 10s/60s/15m 1539.8 1483.2 n/a H/s max 1659.9 H/s
[2021-01-20 17:39:07.465]  net      new job from cryptonote.social:5555 diff 90001 algo rx/0 height 2278699
[2021-01-20 17:39:17.140]  origin   not submitted to origin daemon, difficulty too low (2/2)  diff 259970 vs. 114169
[2021-01-20 17:39:17.490]  cpu      accepted (4/0) diff 90001 (350 ms)
```